### PR TITLE
Bug 978671 - B2G NFC: Add ro.moz.nfc.enabled system proprty to Nexus-5

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -330,6 +330,10 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # for Gecko
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.moz.has_home_button=0 \
+    ro.moz.nfc.enabled=true
+
+PRODUCT_PACKAGES += \
+    nfcd
 
 PRODUCT_COPY_FILES += \
     device/lge/hammerhead/volume.cfg:system/etc/volume.cfg


### PR DESCRIPTION
(hammerhead)
