### PR TITLE
Bug 1086712 - Don't bounce adb connection on boot with N4/N5. r=jld

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -306,10 +306,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.radio.custom_ecc=1
 
-# set default USB configuration
-PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
-    persist.sys.usb.config=mtp
-
 # Request modem to send PLMN name always irrespective
 # of display condition in EFSPN.
 # RIL uses this property.


### PR DESCRIPTION
Remove persist.sys.usb.config altogether.

build/tools/post_process_props.py will make it be "none"
