### PR TITLE
Bug 1189584 - [Nexus 5] Add support for the blobfree build

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "Nexus 5",
+    "adb": {
+      "ro.product.device": [ "hammerhead" ],
+      "ro.bootloader": "HHZ11k",
+      "ro.build.id": "KTU84P"
+    },
+    "fastboot": {
+      "product": [ "hammerhead" ]
+    }
+  }
+]
+

--- a/full_hammerhead.mk
+++ b/full_hammerhead.mk
@@ -30,5 +30,9 @@ PRODUCT_MODEL := AOSP on HammerHead
 PRODUCT_MANUFACTURER := LGE
 PRODUCT_RESTRICT_VENDOR_FILES := true
 
+TARGET_DEVICE_BLOBS := vendor/lge/hammerhead/device-partial.mk \
+                       vendor/broadcom/hammerhead/device-partial.mk \
+                       vendor/qcom/hammerhead/device-partial.mk
+
 $(call inherit-product, device/lge/hammerhead/device.mk)
 $(call inherit-product-if-exists, vendor/lge/hammerhead/device-vendor.mk)


### PR DESCRIPTION
Add definition of TARGET_DEVICE_BLOBS and devices.json.
