### PR TITLE
Bug 1189584 - [Nexus 5 L] Add support for the blobfree build

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "Nexus 5",
+    "adb": {
+      "ro.product.device": [ "hammerhead" ],
+      "ro.bootloader": "HHZ11k",
+      "ro.build.id": ["LMY48I", "LMY48B", "LMY47I", "LMY47D", "LRX22C", "LRX21O"]
+    },
+    "fastboot": {
+      "product": [ "hammerhead" ]
+    }
+  }
+]
+

--- a/full_hammerhead.mk
+++ b/full_hammerhead.mk
@@ -36,6 +36,10 @@ RECOVERY_EXTERNAL_STORAGE := /data/media/0
 # if device deprecates set_perm() and set_perm_recursive()
 export USE_SET_METADATA := true
 
+TARGET_DEVICE_BLOBS := vendor/lge/hammerhead/device-partial.mk \
+                       vendor/broadcom/hammerhead/device-partial.mk \
+                       vendor/qcom/hammerhead/device-partial.mk
+
 $(call inherit-product, device/lge/hammerhead/device.mk)
 $(call inherit-product-if-exists, vendor/lge/hammerhead/device-vendor.mk)
 


### PR DESCRIPTION
Add definition of TARGET_DEVICE_BLOBS and devices.json.
